### PR TITLE
Deprecated methods and memory optimization error correction

### DIFF
--- a/components/tclac/tclac.cpp
+++ b/components/tclac/tclac.cpp
@@ -15,9 +15,12 @@ namespace tclac{
 ClimateTraits tclacClimate::traits() {
 	auto traits = climate::ClimateTraits();
 
-	traits.set_supports_action(false);
-	traits.set_supports_current_temperature(true);
-	traits.set_supports_two_point_target_temperature(false);
+	
+	//traits.set_supports_action(false);
+	//traits.set_supports_current_temperature(true);
+	//traits.set_supports_two_point_target_temperature(false);
+
+	traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE); // Предудущие методы запрещены, теперь нужно использовать add_feature_flags
 
 	traits.set_supported_modes(this->supported_modes_);
 	traits.set_supported_presets(this->supported_presets_);
@@ -685,7 +688,7 @@ void tclacClimate::set_vertical_swing_direction(VerticalSwingDirection direction
 	}
 }
 // Получение доступных режимов работы кондиционера
-void tclacClimate::set_supported_modes(const std::set<climate::ClimateMode> &modes) {
+void tclacClimate::set_supported_modes(climate::ClimateModeMask modes) {
 	this->supported_modes_ = modes;
 }
 // Получение режима качания горизонтальных заслонок
@@ -698,17 +701,18 @@ void tclacClimate::set_horizontal_swing_direction(HorizontalSwingDirection direc
 	}
 }
 // Получение доступных скоростей вентилятора
-void tclacClimate::set_supported_fan_modes(const std::set<climate::ClimateFanMode> &modes){
+void tclacClimate::set_supported_fan_modes(climate::ClimateFanModeMask modes){
 	this->supported_fan_modes_ = modes;
 }
 // Получение доступных режимов качания заслонок
-void tclacClimate::set_supported_swing_modes(const std::set<climate::ClimateSwingMode> &modes) {
+void tclacClimate::set_supported_swing_modes(climate::ClimateSwingModeMask modes) {
 	this->supported_swing_modes_ = modes;
 }
 // Получение доступных предустановок
-void tclacClimate::set_supported_presets(const std::set<climate::ClimatePreset> &presets) {
+void tclacClimate::set_supported_presets(climate::ClimatePresetMask presets) {
   this->supported_presets_ = presets;
 }
+
 
 }
 }

--- a/components/tclac/tclac.h
+++ b/components/tclac/tclac.h
@@ -133,22 +133,22 @@ class tclacClimate : public climate::Climate, public esphome::uart::UARTDevice, 
 		void set_horizontal_airflow(AirflowHorizontalDirection direction);
 		void set_vertical_swing_direction(VerticalSwingDirection direction);
 		void set_horizontal_swing_direction(HorizontalSwingDirection direction);
-		void set_supported_presets(const std::set<climate::ClimatePreset> &presets);
-		void set_supported_modes(const std::set<esphome::climate::ClimateMode> &modes);
-		void set_supported_fan_modes(const std::set<esphome::climate::ClimateFanMode> &modes);
-		void set_supported_swing_modes(const std::set<esphome::climate::ClimateSwingMode> &modes);
+		void set_supported_presets(climate::ClimatePresetMask presets);
+		void set_supported_modes(climate::ClimateModeMask modes);
+		void set_supported_fan_modes(climate::ClimateFanModeMask modes);
+		void set_supported_swing_modes(climate::ClimateSwingModeMask modes);
 		
 	protected:
 		GPIOPin *rx_led_pin_;
 		GPIOPin *tx_led_pin_;
 		ClimateTraits traits() override;
-		std::set<ClimateMode> supported_modes_{};
-		std::set<ClimatePreset> supported_presets_{};
+		climate::ClimateModeMask supported_modes_{};
+		climate::ClimatePresetMask supported_presets_{};
 		AirflowVerticalDirection vertical_direction_;
-		std::set<ClimateFanMode> supported_fan_modes_{};
+		climate::ClimateFanModeMask supported_fan_modes_{};
 		AirflowHorizontalDirection horizontal_direction_;
 		VerticalSwingDirection vertical_swing_direction_;
-		std::set<ClimateSwingMode> supported_swing_modes_{};
+		climate::ClimateSwingModeMask supported_swing_modes_{};
 		HorizontalSwingDirection horizontal_swing_direction_;
 };
 }


### PR DESCRIPTION
Закомментировал запрещенные (Deprecated) методы, вместо них добавил add_feature_flags,
так же поправил в соответствии со статьей https://developers.esphome.io/blog/2025/11/07/climate-entity-class-finitesetmask-and-flash-storage-optimizations/ 
теперь компилируется и работает на ESPHome 2025.11.0