### PR TITLE
fix: бит дисплея не должен входить в маску режима — «всегда AUTO при погашенном дисплее» (issue #22)

### DIFF
--- a/components/tclac/tclac.cpp
+++ b/components/tclac/tclac.cpp
@@ -157,6 +157,13 @@ void tclacClimate::readData() {
 	if (dataRX[MODE_POS] & ( 1 << 4)) {
 		// Если кондиционер включен, то разбираем данные для отображения
 		ESP_LOGD("TCL", "AC is on");
+
+		// Синхронизируем состояние дисплея с фактическим (бит DISPLAY_BIT в
+		// байте режима): пультом дисплей переключается мимо модуля, и без
+		// синхронизации следующая команда модуля перетирала бы состояние
+		// дисплея старым значением. Только когда кондиционер включён.
+		this->display_status_ = (dataRX[MODE_POS] & DISPLAY_BIT) != 0;
+
 		uint8_t modeswitch = MODE_MASK & dataRX[MODE_POS];
 		uint8_t fanspeedswitch = FAN_SPEED_MASK & dataRX[FAN_SPEED_POS];
 		uint8_t swingmodeswitch = SWING_MODE_MASK & dataRX[SWING_POS];

--- a/components/tclac/tclac.h
+++ b/components/tclac/tclac.h
@@ -19,13 +19,17 @@ namespace tclac {
 #define SET_TEMP_MASK	0b00001111
 
 #define MODE_POS		7
-#define MODE_MASK		0b00111111
+// Бит 0b00100000 в байте режима — состояние ДИСПЛЕЯ кондиционера, он не
+// должен участвовать в определении режима (иначе с погашенным дисплеем
+// любой режим читается как "не распознан" и падает в default = AUTO)
+#define DISPLAY_BIT		0b00100000
+#define MODE_MASK		0b00001111
 
-#define MODE_AUTO		0b00110101
-#define MODE_COOL		0b00110001
-#define MODE_DRY		0b00110011
-#define MODE_FAN_ONLY	0b00110010
-#define MODE_HEAT		0b00110100
+#define MODE_AUTO		0b00000101
+#define MODE_COOL		0b00000001
+#define MODE_DRY		0b00000011
+#define MODE_FAN_ONLY	0b00000010
+#define MODE_HEAT		0b00000100
 
 #define FAN_SPEED_POS	8
 #define FAN_QUIET_POS	33
@@ -121,6 +125,9 @@ class tclacClimate : public climate::Climate, public esphome::uart::UARTDevice, 
 		void update() override;
 		void set_beeper_state(bool state);
 		void set_display_state(bool disp_state);
+		// Фактическое состояние дисплея кондиционера (синхронизируется из
+		// статусных кадров в readData)
+		bool get_display_state() { return this->display_status_; }
 		void dataShow(bool flow, bool shine);
 		void set_force_mode_state(bool f_state);
 		void set_rx_led_pin(GPIOPin *rx_led_pin);


### PR DESCRIPTION
<!-- Заголовок PR:
fix: бит дисплея не должен входить в маску режима — «всегда AUTO при погашенном дисплее» (issue #22)
base: I-am-nightingale/tclac master  <-  head: VolkMicro/tclac-upstream pr/fix-mode-mask
-->

Здравствуйте! Спасибо за компонент — пользуемся им с Wiren Board, кондиционер iFFALCON F1 18 ONF/R (TCL). Нашли и починили причину «с погашенным дисплеем всё показывается как Авто» — это то самое поведение из issue #22, и оно оказалось не особенностью кондиционера, а багом разбора статусного кадра.

## Симптом

При выключенном дисплее внутреннего блока климат-сущность всегда показывает
режим Auto, смена режима «не работает». В issue #22 это было закрыто как
характеристика кондиционера.

## Причина

Бит `0b00100000` в байте режима (байт 7 статусного кадра) — это **состояние
дисплея**, а не часть кода режима. Сейчас он входит и в `MODE_MASK`
(`0b00111111`), и во все константы `MODE_*`:

```
Экран горит:  байт7 = 0x31 = 0b00110001  → совпадает с MODE_COOL ✓
Экран потух:  байт7 = 0x11 = 0b00010001  → не совпадает ни с чем → default → AUTO
```

Кондиционер при этом реально остаётся в своём режиме (продолжает охлаждать) —
неправильно только отображение. Проверяется просто: пультом ставится
COOL + тёмный экран, дампы кадров до/после отличаются одним битом.

## Что меняет PR

- `MODE_MASK = 0b00001111`, бит дисплея вынесен в отдельный `DISPLAY_BIT`,
  константы `MODE_*` приведены к младшему нибблу (switch-код не меняется);
- `display_status_` синхронизируется из статусного кадра (только когда
  кондиционер включён): нажатие кнопки дисплея на пульте становится видно
  модулю, и команды модуля больше не перетирают состояние экрана старым
  значением;
- добавлен `get_display_state()` для внешних интеграций.

После фикса: дисплей можно гасить и пультом, и из модуля — режимы
отображаются и переключаются корректно. Проверено на живом кондиционере
(iFFALCON F1 18 ONF/R, ESP32-C3).

Диff небольшой (+21/−7), логика switch не тронута. Если удобнее другое
оформление — скажите, поправлю.
