### PR TITLE
fix: make component framework-neutral (ESP-IDF & Arduino compatible)

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,33 @@
+name: Compile ESPHome component
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - tests/test.esp32-ard.yaml
+          - tests/test.esp32-idf.yaml
+        esphome:
+          - "2026.4.0"
+          - "2026.7.3"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ESPHome
+        run: python -m pip install "esphome==${{ matrix.esphome }}"
+
+      - name: Compile
+        run: esphome compile "${{ matrix.config }}"

--- a/components/tclac/tclac.cpp
+++ b/components/tclac/tclac.cpp
@@ -382,6 +382,10 @@ void tclacClimate::takeControl() {
 			dataTX[7] += 0b00000100;
 			dataTX[8] += 0b00000001;	
 			break;
+		case climate::CLIMATE_MODE_AUTO:
+			// Этот режим ESPHome не используется компонентом TCLAC.
+			// Для автоматического режима TCLAC использует CLIMATE_MODE_HEAT_COOL.
+			break;
 	}
 
 	// Настраиваем режим вентилятора
@@ -419,6 +423,10 @@ void tclacClimate::takeControl() {
 				dataTX[8]	+= 0b01000000;
 				dataTX[10]	+= 0b00000000;
 				break;
+			case climate::CLIMATE_FAN_ON:
+			case climate::CLIMATE_FAN_OFF:
+				// Эти общие режимы ESPHome не поддерживаются протоколом TCLAC.
+				break;
 		}
 	}
 	
@@ -455,6 +463,12 @@ void tclacClimate::takeControl() {
 				break;
 			case ClimatePreset::CLIMATE_PRESET_COMFORT:
 				dataTX[8]	+= 0b00010000;
+				break;
+			case ClimatePreset::CLIMATE_PRESET_HOME:
+			case ClimatePreset::CLIMATE_PRESET_AWAY:
+			case ClimatePreset::CLIMATE_PRESET_BOOST:
+			case ClimatePreset::CLIMATE_PRESET_ACTIVITY:
+				// Эти стандартные пресеты ESPHome не поддерживаются протоколом TCLAC.
 				break;
 		}
 	}

--- a/components/tclac/tclac.cpp
+++ b/components/tclac/tclac.cpp
@@ -4,6 +4,8 @@
 * Refactoring & component making:
 * Соловей с паяльником 15.03.2024
 **/
+#include <cmath>
+
 #include "esphome.h"
 #include "esphome/core/defines.h"
 #include "tclac.h"
@@ -327,7 +329,7 @@ void tclacClimate::takeControl() {
 	
 	// Защита от мусора в байте уставки: до первого статусного кадра
 	// target_temperature = NaN, а (int)NaN — неопределённое поведение.
-	if (isnan(target_temperature) || target_temperature < 16 || target_temperature > 31) {
+	if (std::isnan(target_temperature) || target_temperature < 16 || target_temperature > 31) {
 		target_temperature = 24;
 	}
 	uint8_t target_temperature_set = 31-(int)target_temperature;
@@ -683,16 +685,19 @@ void tclacClimate::try_send_frame_(uint8_t attempt, uint8_t defers_left) {
 	this->esphome::uart::UARTDevice::flush();
 }
 
-// Преобразование байта в читабельный формат
-String tclacClimate::getHex(uint8_t *message, uint8_t size) {
-	String raw;
-	for (int i = 0; i < size; i++) {
-		raw += "\n" + String(message[i]);
+// Преобразование байта в читабельный формат.
+// Используется std::string вместо Arduino String,
+// поэтому функция работает как с Arduino, так и с ESP-IDF.
+std::string tclacClimate::getHex(const uint8_t *message, size_t size) {
+	std::string raw;
+
+	for (size_t i = 0; i < size; i++) {
+		raw += "\n";
+		raw += std::to_string(message[i]);
 	}
-	raw.toUpperCase();
+
 	return raw;
 }
-
 // Вычисление контрольной суммы
 uint8_t tclacClimate::getChecksum(const uint8_t * message, size_t size) {
 	uint8_t position = size - 1;

--- a/components/tclac/tclac.cpp
+++ b/components/tclac/tclac.cpp
@@ -647,7 +647,7 @@ void tclacClimate::sendData(uint8_t * message, uint8_t size) {
 		if (k == 0) {
 			this->try_send_frame_(0, TX_MAX_DEFERS);
 		} else {
-			esphome::App.scheduler.set_timeout("tx_rep", k * TX_REPEAT_SPACING_MS, [this, k]() {
+			this->set_timeout(k * TX_REPEAT_SPACING_MS, [this, k]() {
 				this->try_send_frame_(k, TX_MAX_DEFERS);
 			});
 		}
@@ -675,7 +675,7 @@ bool tclacClimate::bus_quiet_() {
 // Отправить кадр, если линия свободна; иначе отложить на BUS_QUIET_MS
 void tclacClimate::try_send_frame_(uint8_t attempt, uint8_t defers_left) {
 	if (!this->bus_quiet_() && defers_left > 0) {
-		esphome::App.scheduler.set_timeout("tx_def", BUS_QUIET_MS,
+		this->set_timeout(BUS_QUIET_MS,
 			[this, attempt, defers_left]() {
 				this->try_send_frame_(attempt, defers_left - 1);
 			});

--- a/components/tclac/tclac.h
+++ b/components/tclac/tclac.h
@@ -8,6 +8,8 @@
 #ifndef TCL_ESP_TCL_H
 #define TCL_ESP_TCL_H
 
+#include <string>
+
 #include "esphome.h"
 #include "esphome/core/defines.h"
 #include "esphome/components/uart/uart.h"
@@ -165,7 +167,7 @@ class tclacClimate : public climate::Climate, public esphome::uart::UARTDevice, 
 		void set_tx_led_pin(GPIOPin *tx_led_pin);
 		void sendData(uint8_t * message, uint8_t size);
 		void set_module_display_state(bool d_state);
-		static String getHex(uint8_t *message, uint8_t size);
+		static std::string getHex(const uint8_t *message, size_t size);
 		static uint8_t getChecksum(const uint8_t * message, size_t size);
 		void set_vertical_airflow(AirflowVerticalDirection v_airflow);
 		void set_horizontal_airflow(AirflowHorizontalDirection h_airflow);

--- a/tests/test.esp32-ard.yaml
+++ b/tests/test.esp32-ard.yaml
@@ -1,0 +1,29 @@
+esphome:
+  name: tclac-test-arduino
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+logger:
+
+uart:
+  id: tclac_test_uart
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 9600
+  data_bits: 8
+  parity: EVEN
+  stop_bits: 1
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [tclac]
+
+climate:
+  - platform: tclac
+    id: tclac_test_climate
+    name: TCL AC Test

--- a/tests/test.esp32-idf.yaml
+++ b/tests/test.esp32-idf.yaml
@@ -1,0 +1,29 @@
+esphome:
+  name: tclac-test-idf
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+
+uart:
+  id: tclac_test_uart
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 9600
+  data_bits: 8
+  parity: EVEN
+  stop_bits: 1
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [tclac]
+
+climate:
+  - platform: tclac
+    id: tclac_test_climate
+    name: TCL AC Test


### PR DESCRIPTION
## Description
This PR makes the `tclac` climate component framework-neutral, enabling it to build and run seamlessly under both **ESP-IDF** and **Arduino** frameworks in ESPHome.

### Key Changes
1. **Standard C++ replacement for Arduino String**: Replaced Arduino `String` in `getHex()` with `std::string` to allow framework-independent builds without removing debug functionality.
2. **Standard C++ `std::isnan`**: Replaced `isnan` with `std::isnan` and included `<cmath>`.
3. **ESPHome Component Timeout API**: Replaced direct `App.scheduler.set_timeout` calls with `this->set_timeout()` for compatibility with ESPHome 2026.4+ and to prevent named timeouts from overwriting each other.
4. **Explicit Enum Handling**: Added explicit `break;` cases for unsupported climate modes, fan modes, and presets to eliminate compiler `-Wswitch` warnings without swallowing future ESPHome enum updates.
5. **CI & Compile Tests**: Added CI matrix test workflow (`.github/workflows/compile.yml`) compiling against both ESP-IDF and Arduino under ESPHome 2026.4.0 and 2026.7.3.

### Verification
  All 4 CI matrix build targets compile cleanly:
  - ESPHome 2026.4.0 (Arduino) ✅
  - ESPHome 2026.4.0 (ESP-IDF) ✅
  - ESPHome 2026.7.3 (Arduino) ✅
  - ESPHome 2026.7.3 (ESP-IDF) ✅